### PR TITLE
Changes to load the libraries properly using cmake's FetchContent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -301,3 +301,4 @@ vs-readme.txt
 **/.pio
 .development
 cmake-build-*
+build

--- a/cmakeProject/CMakeLists.txt
+++ b/cmakeProject/CMakeLists.txt
@@ -9,14 +9,8 @@ set(CMAKE_CXX_STANDARD 17)
 
 pico_sdk_init()
 
-add_subdirectory(lib/TcMenuLog/cmake)
-add_subdirectory(lib/SimpleCollections/cmake)
-add_subdirectory(lib/TaskManagerIO/cmake)
-add_subdirectory(lib/IoAbstraction/cmake)
-add_subdirectory(lib/tcMenu/cmake)
-add_subdirectory(lib/tcUnicodeHelper/cmake)
-add_subdirectory(lib/LiquidCrystalIO/cmake)
-add_subdirectory(mbed_lib/Adafruit-GFX-mbed-fork/cmake)
+include(libraries.cmake)
+includeLibraries()
 
 IF(NOT DEFINED "ENV{TC_CMAKE_EXCLUDE_EXAMPLES}")
     add_subdirectory(nativeExamples/UsingCollections)

--- a/cmakeProject/README.md
+++ b/cmakeProject/README.md
@@ -1,6 +1,7 @@
 ## Pico SDK build via CMake
 
-Use this directory to build using CMake for PicoSDK. You simply point a cmake compatible IDE at this directory and it should be able to load the project structure. Disclaimer only tried with CLion.
+Use this directory to build using CMake for PicoSDK. You simply point a cmake compatible IDE at this directory and it should be able to load the project structure. Disclaimer only tried with CLion and VSCode with the
+pico plugin and the cmake plugins respectivly.
 
 To use you'll need to set the following variables.
 
@@ -14,7 +15,7 @@ This build is Apache license. Consult each library for their license.
 
 ## Using our libraries in Arduino and PlatformIO
 
-Use the top level platformio.ini file for that purpose.
+Use the top level `platformio.ini` file for that purpose. 
 
 ## Working with Native tool chains in production
 
@@ -23,9 +24,10 @@ _Commercial users: Before asking any questions in the tcMenu discussion board ab
 We can support this toolchain on RP2040 PicoSDK, ESP-IDF, STM32Cube, Atmel AVR and SAMD. Please the the above link for more information.
 
 Environment variables needed for PicoSDK:
-
+    ```
     PICO_SDK_PATH=<your picosdk path>
     PICO_TOOLCHAIN_PATH=<path of arm toolchain>
+    ```
 
 ## How to use these libraries
 
@@ -38,14 +40,11 @@ Here are the links to the libraries needed in the lib directory
 * https://github.com/TcMenu/SimpleCollections
 * https://github.com/TcMenu/LiquidCrystalIO
 * https://github.com/TcMenu/TcMenuLog
-
-Recommended libraries in cmakeProject/mbed_lib
-
 * https://github.com/TcMenu/Adafruit-GFX-mbed-fork provides an Adafruit_GFX compatibile graphics library.
 
 ### Using in PicoSDK
 
-As per all other PicoSDK applications, you need to set up the environment variables and ensure these libraries are available in the path. For the initial MVP we assume you have a local to project copy of these libraries similar to how the examples folder works, we'll sort this out properly after 4.2 and mobile app is released.
+As per all other PicoSDK applications, you need to set up the environment variables and ensure these libraries are available in the path.
 
 # Current state of play for direct pico-sdk / outside Arduino use
 
@@ -66,8 +65,26 @@ As per all other PicoSDK applications, you need to set up the environment variab
 
 ## To Test
 
-* Check that AT24 EEPROMs are working properly.
-* The copy script and setup of the libraries.
+* Copy libraries.cmake to your project
+* Add the following to your `CMakeLists.txt` after `pico_sdk_init()`
+    ```
+    include(libraries.cmake)
+    includeLibraries()
+    ```
+* Add the following to your `CMakeLists.txt` in the `target_link_libraries`
+    ```
+    tcMenu
+    IoAbstraction
+    TaskManagerIO
+    tcUnicodeHelper
+    TcMenuLog
+    SimpleCollections
+    AdafruitGFXNativePort
+    ```
+    Leave `AdafruitGFXNativePort` out if not needed.
+* Build.
+* The libraries will be in `build/_deps`.
+
 
 ## Todo short term
 

--- a/cmakeProject/libraries.cmake
+++ b/cmakeProject/libraries.cmake
@@ -1,0 +1,77 @@
+cmake_minimum_required(VERSION 3.13)
+
+function (includeLibraries)
+include(FetchContent)
+
+#  Include these libraries in CMakeLists.txt
+# tcMenu
+# IoAbstraction
+# TaskManagerIO
+# tcUnicodeHelper
+# TcMenuLog
+# AdafruitGFXNativePort
+# SimpleCollections
+
+
+SET(TCMENU_BASE_GIT_REPO "https://github.com/mwinters-stuff")
+# SET(TCMENU_BASE_GIT_REPO "https://github.com/TcMenu/tcMenuLib.git")
+
+# Fetch the TcMenu git repo
+FetchContent_Declare(
+    tcMenuLib
+    GIT_REPOSITORY ${TCMENU_BASE_GIT_REPO}/tcMenuLib.git
+    GIT_TAG        main # Use a stable branch, tag, or commit hash
+    SOURCE_SUBDIR  cmake
+)
+
+# Fetch the IoAbstraction git repo
+FetchContent_Declare(
+    IoAbstraction
+    GIT_REPOSITORY ${TCMENU_BASE_GIT_REPO}/IoAbstraction.git
+    GIT_TAG        main # Use a stable branch, tag, or commit hash
+    SOURCE_SUBDIR  cmake
+)
+
+# Fetch the TaskManagerIO git repo
+FetchContent_Declare(
+    TaskManagerIO
+    GIT_REPOSITORY ${TCMENU_BASE_GIT_REPO}/TaskManagerIO.git
+    GIT_TAG        main # Use a stable branch, tag, or commit hash
+    SOURCE_SUBDIR  cmake
+)
+
+# Fetch the TcUnicodeHelper git repo
+FetchContent_Declare(
+    TcUnicodeHelper
+    GIT_REPOSITORY ${TCMENU_BASE_GIT_REPO}/TcUnicodeHelper.git
+    GIT_TAG        main # Use a stable branch, tag, or commit hash
+    SOURCE_SUBDIR  cmake
+)
+
+# Fetch the TcMenuLog git repo
+FetchContent_Declare(
+    TcMenuLog
+    GIT_REPOSITORY ${TCMENU_BASE_GIT_REPO}/TcMenuLog.git
+    GIT_TAG        main # Use a stable branch, tag, or commit hash
+    SOURCE_SUBDIR  cmake
+)
+
+# Fetch the Adafruit-GFX-mbed-fork git repo
+FetchContent_Declare(
+    AdafruitGFX
+    GIT_REPOSITORY ${TCMENU_BASE_GIT_REPO}/Adafruit-GFX-mbed-fork.git
+    GIT_TAG        main # Use a stable branch, tag, or commit hash
+    SOURCE_SUBDIR  cmake
+)
+
+# Fetch the SimpleCollections git repo
+FetchContent_Declare(
+    SimpleCollections
+    GIT_REPOSITORY ${TCMENU_BASE_GIT_REPO}/SimpleCollections.git
+    GIT_TAG        main # Use a stable branch, tag, or commit hash
+    SOURCE_SUBDIR  cmake
+)
+
+FetchContent_MakeAvailable(tcMenuLib IoAbstraction TaskManagerIO TcUnicodeHelper TcMenuLog AdafruitGFX SimpleCollections)
+
+endfunction()


### PR DESCRIPTION
In trying out the tcMenu, i found it not easy to use as the libraries had to be exported and pushed into very specific locations. Having done cmake libraries for the pico-sdk, I was able to make the required changes to properly import the sdk using cmake.

The `CMakeLists.txt` for each library has had the paths fixed,  so that it can be used with the `libraries.cmake` that is in this or `FetchContent`  from cmake.

The `CMakeLists.txt` in this library has been updated to use `libraries.cmake` which will load all libraries into the `build/_deps` and build them in there.

A user of the libraries only needs to add in the `libraries.cmake` and add the extra lines that are now in the `readme.md`

The libraries all have PR's with the changes to their `CMakeLists.txt`. The `libraries.cmake` is currently pointing at my forks and can be easily changed when needed.

### Libraries PR's
https://github.com/TcMenu/tcUnicodeHelper/pull/16
https://github.com/TcMenu/Adafruit-GFX-mbed-fork/pull/6
https://github.com/TcMenu/SimpleCollections/pull/14
https://github.com/TcMenu/TcMenuLog/pull/8
https://github.com/TcMenu/TaskManagerIO/pull/64
https://github.com/TcMenu/IoAbstraction/pull/216
https://github.com/TcMenu/tcMenuLib/pull/240